### PR TITLE
ロギングの設定

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ target/
 .metals/
 .vscode/
 .bloop/
+*.log

--- a/build.sbt
+++ b/build.sbt
@@ -15,4 +15,5 @@ lazy val root = (project in file("."))
     commonSettings,
     libraryDependencies += akkaActorTyped,
     libraryDependencies += scalaTest,
+    libraryDependencies += logback % Runtime
   )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,10 @@ import sbt._
 object Dependencies {
   val AkkaActor = "2.6.19"
 
-  lazy val catsCore =  "org.typelevel" %% "cats-core" % "2.6.1" //catsは標準ライブラリ扱い
+  lazy val catsCore = "org.typelevel" %% "cats-core" % "2.6.1" //catsは標準ライブラリ扱い
   lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.2.10" % Test
-  lazy val akkaActorTyped = "com.typesafe.akka" %% "akka-actor-typed" % AkkaActor
+  lazy val akkaActorTyped =
+    "com.typesafe.akka" %% "akka-actor-typed" % AkkaActor
+
+  val logback = "ch.qos.logback" % "logback-classic" % "1.2.11"
 }

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+<!--        <pattern>[%date{ISO8601}] [%level] [%logger] [%marker] [%thread] - %msg MDC: {%mdc}%n</pattern>-->
+            <pattern>[%date{ISO8601}] [%level] [%logger] - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="ASYNC" class="ch.qos.logback.classic.AsyncAppender">
+        <queueSize>8192</queueSize>
+        <neverBlock>true</neverBlock>
+        <appender-ref ref="STDOUT" />
+    </appender>
+
+    <root level="DEBUG">
+        <appender-ref ref="ASYNC"/>
+    </root>
+</configuration>

--- a/src/main/scala/com/serviveragent/actortest/Module.scala
+++ b/src/main/scala/com/serviveragent/actortest/Module.scala
@@ -8,6 +8,7 @@ object Module:
 
   def createModule(): Behavior[NotUsed] =
     Behaviors.setup { context =>
+      context.log.info("initializing the module...")
       val receiveBox = context.spawn(ReceiveBox(), "ReceiveBox")
       val amplifier = context.spawn(Amplifier(receiveBox), "Amplifier")
 

--- a/src/main/scala/com/serviveragent/actortest/ReceiveBox.scala
+++ b/src/main/scala/com/serviveragent/actortest/ReceiveBox.scala
@@ -5,7 +5,7 @@ import akka.actor.typed.scaladsl.Behaviors
 
 object ReceiveBox:
 
-  def apply(): Behavior[Signal] = Behaviors.receiveMessage { signal =>
-    println(signal)
+  def apply(): Behavior[Signal] = Behaviors.receive { (context, signal) =>
+    context.log.info("{}", signal)
     Behaviors.same
   }


### PR DESCRIPTION
logbackを利用した。
ログを出力するには `context.log.info(...)` 等を利用するとよい。

なおアプリケーション起動時に以下のログが出る。
どうやらLogbackは初期化中にログを出したいという状況になるらしく、回避する方法がわからない。

```
SLF4J: A number (1) of logging calls during the initialization phase have been intercepted and are
SLF4J: now being replayed. These are subject to the filtering rules of the underlying logging system.
SLF4J: See also http://www.slf4j.org/codes.html#replay
```